### PR TITLE
【已审核】feat(desktop): 拖拽时隐藏原图标 + 回收站显示开关

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -920,9 +920,12 @@ public partial class MainWindow : Window
         foreach (var iv in _icons.Values)
         {
             iv.Canon = Desktop.EffectiveCanon(Path.GetFileName(iv.Entry.Path));
-            // 自愈：拖拽/剪切之外不允许有半透明残留（曾有捕获被打断导致留影卡死的实例）
-            if (iv.Root.Opacity < 1 && !_dragGhosts.Contains(iv) && !_cutIcons.Contains(iv))
-                iv.Root.Opacity = 1;
+            // 自愈：拖拽/剪切之外不允许有半透明残留或隐藏（曾有捕获被打断导致留影/卡隐藏的实例）
+            if (!_dragGhosts.Contains(iv) && !_cutIcons.Contains(iv))
+            {
+                if (iv.Root.Opacity < 1) iv.Root.Opacity = 1;
+                if (iv.Root.Visibility != Visibility.Visible) iv.Root.Visibility = Visibility.Visible;
+            }
         }
 
         var placed = new HashSet<(int, int)>();
@@ -1660,6 +1663,7 @@ public partial class MainWindow : Window
 
         // 抓取基准一律用按下点（不是过阈值那一刻的光标）：拖拽图像出现时正好覆盖原图标，
         // 落位 = 图像视觉位置，拿起-放回零漂移
+        // 必须在 Visibility 变更前调用 RenderDragImage：VisualBrush 需要可见元素抓取位图
         var (image, hotspot) = RenderDragImage(group, iv.DownPos);
         double ax = double.IsNaN(Canvas.GetLeft(iv.Root)) ? 0 : Canvas.GetLeft(iv.Root);
         double ay = double.IsNaN(Canvas.GetTop(iv.Root)) ? 0 : Canvas.GetTop(iv.Root);
@@ -1672,7 +1676,7 @@ public partial class MainWindow : Window
         double homeX = group.Min(g => double.IsNaN(Canvas.GetLeft(g.Root)) ? 0 : Canvas.GetLeft(g.Root));
         double homeY = group.Min(g => double.IsNaN(Canvas.GetTop(g.Root)) ? 0 : Canvas.GetTop(g.Root));
 
-        foreach (var g in group) { g.Root.Opacity = 0.35; _dragGhosts.Add(g); PokeElement(g.Root, 200); } // 原位留影
+        foreach (var g in group) { g.Root.Visibility = Visibility.Collapsed; _dragGhosts.Add(g); } // 原位隐藏，拖拽图像跟手
         DragDropEffects? result = null;
         try { result = ShellDrag.Start(filePaths, allPaths, image, hotspot); }
         catch (Exception ex) { Log.Write("drag failed: " + ex.Message); }
@@ -1684,12 +1688,12 @@ public partial class MainWindow : Window
         if (result == null)
         {
             // 取消（Esc/右键/无效落点）：拖拽图像从取消点飞回原位（Finder 手感），
-            // 动画落地才恢复原图标透明度（期间 _dragGhosts 豁免自愈）
+            // 动画落地才恢复原图标可见性（期间 _dragGhosts 豁免自愈）
             SpringBack(group, image, hotspot, new Point(homeX, homeY));
         }
         else
         {
-            foreach (var g in group) { g.Root.Opacity = 1; PokeElement(g.Root, 150); }
+            foreach (var g in group) { g.Root.Visibility = Visibility.Visible; PokeElement(g.Root, 150); }
             _dragGhosts.Clear();
         }
         // 后续：拖回自己/兄弟窗口 → OnDesktopDrop 重定位；Move 去外部 → FileSystemWatcher 移除图标
@@ -1727,7 +1731,7 @@ public partial class MainWindow : Window
         void Land()
         {
             IconCanvas.Children.Remove(ghost);
-            foreach (var g in group) { g.Root.Opacity = 1; PokeElement(g.Root, 150); }
+            foreach (var g in group) { g.Root.Visibility = Visibility.Visible; PokeElement(g.Root, 150); }
             _dragGhosts.Clear();
         }
         var dur = TimeSpan.FromMilliseconds(220);
@@ -2703,7 +2707,12 @@ public partial class MainWindow : Window
             if (iv != null)
             {
                 iv.Canon = canon;
-                // 自由摆放瞬置（零漂移）；网格模式从落点滑行到吸附格（回归被误删的动画）
+                if (!Config.FreePlacement && ctx != null)
+                {
+                    // 自家拖拽网格模式：先瞬移到视觉落点，再滑行到吸附格（否则动画从拖拽前旧位置起跑）
+                    MoveIcon(iv, dl, dt, animated: false);
+                }
+                // 自由摆放瞬置（零漂移）；网格模式从落点滑行到吸附格
                 MoveIcon(iv, fl, ft, animated: !Config.FreePlacement);
             }
             else

--- a/Services/DesktopItemProvider.cs
+++ b/Services/DesktopItemProvider.cs
@@ -36,7 +36,9 @@ internal sealed class DesktopItemProvider : IDisposable
 
     public IReadOnlyList<DesktopEntry> Enumerate()
     {
-        var result = new List<DesktopEntry> { new(RecycleBin, "Recycle Bin") };
+        var result = new List<DesktopEntry>();
+        if (Desktop.Config.ShowRecycleBin)
+            result.Add(new DesktopEntry(RecycleBin, "Recycle Bin"));
         foreach (var dir in new[] { UserDesktop, PublicDesktop })
         {
             if (!Directory.Exists(dir)) continue;

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -1,9 +1,10 @@
 using System.IO;
 using System.Text.Json;
+using Microsoft.Win32;
 
 namespace MacDesk.Services;
 
-/// <summary>轻量用户设置（%LOCALAPPDATA%\MacDesk\settings.json）。目前只有自由摆放开关。</summary>
+/// <summary>轻量用户设置（%LOCALAPPDATA%\MacDesk\settings.json）。</summary>
 internal sealed class Settings
 {
     private readonly string _file;
@@ -62,6 +63,22 @@ internal sealed class Settings
     /// 默认 64。Ctrl +/- 与外观页滑杆调整；不写 Canon（切档=切分辨率同理，仅显示现算）。</summary>
     public int IconSize { get; set; } = 64;
 
+    /// <summary>在桌面上显示回收站图标。未保存过设置时跟随原生桌面：原生桌面上回收站可见则默认开，否则关。</summary>
+    public bool ShowRecycleBin { get; set; } = IsRecycleBinVisibleOnNativeDesktop();
+
+    /// <summary>读取原生桌面回收站是否可见（Windows 10+ 注册表）。</summary>
+    private static bool IsRecycleBinVisibleOnNativeDesktop()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel");
+            // 值不存在或为 0 = 可见，值为 1 = 隐藏
+            return key?.GetValue("{645FF040-5081-101B-9F08-00AA002F954E}") is not int v || v == 0;
+        }
+        catch { return true; }
+    }
+
     /// <summary>软件渲染（等效 --soft）：整进程绕开显卡走 WPF 软件光栅化。个别核显驱动在
     /// 硬件合成路径把壁纸镜像亮部烧成彩色噪点（issue #1：Intel UHD 630，升最新驱动无效，
     /// 软件渲染实测干净）。默认关（绝大多数显卡正常，软件渲染白费 CPU）。重启生效。</summary>
@@ -101,6 +118,7 @@ internal sealed class Settings
                 if (doc.RootElement.TryGetProperty("SpacePreview", out var sp)) s.SpacePreview = sp.GetBoolean();
                 if (doc.RootElement.TryGetProperty("NativeBackgroundMenu", out var nb)) s.NativeBackgroundMenu = nb.GetBoolean();
                 if (doc.RootElement.TryGetProperty("IconSize", out var iz) && iz.ValueKind == JsonValueKind.Number) s.IconSize = iz.GetInt32();
+                if (doc.RootElement.TryGetProperty("ShowRecycleBin", out var srb)) s.ShowRecycleBin = srb.GetBoolean();
                 if (doc.RootElement.TryGetProperty("SoftwareRender", out var sr)) s.SoftwareRender = sr.GetBoolean();
             }
         }
@@ -113,7 +131,7 @@ internal sealed class Settings
         try
         {
             File.WriteAllText(_file, JsonSerializer.Serialize(
-                new { FreePlacement, MenuBlacklist, MenuInMainProcess, AccentColor, UseStacks, StackGroupBy, DynamicWallpaper, DynamicNoShadows, DynamicNoAnimations, FastAutostart, Language, SpacePreview, NativeBackgroundMenu, IconSize, SoftwareRender },
+                new { FreePlacement, MenuBlacklist, MenuInMainProcess, AccentColor, UseStacks, StackGroupBy, DynamicWallpaper, DynamicNoShadows, DynamicNoAnimations, FastAutostart, Language, SpacePreview, NativeBackgroundMenu, IconSize, ShowRecycleBin, SoftwareRender },
                 new JsonSerializerOptions { WriteIndented = true }));
         }
         catch { }

--- a/SettingsWindow.cs
+++ b/SettingsWindow.cs
@@ -528,6 +528,13 @@ internal sealed class SettingsWindow : Window
         startup.Children.Add(Row(L.T("语言 / Language", "Language / 语言"), langBox,
             L.T("重启 MacDesk 生效", "Takes effect after restarting MacDesk")));
         startup.Children.Add(Separator());
+        startup.Children.Add(Row(L.T("显示回收站", "Show Recycle Bin"), Toggle(Config.ShowRecycleBin, v =>
+        {
+            Config.ShowRecycleBin = v;
+            Config.Save();
+            Desktop.RefreshAll();
+        }), L.T("在桌面上显示回收站图标", "Show the Recycle Bin icon on the desktop")));
+        startup.Children.Add(Separator());
         startup.Children.Add(Row(L.T("空格预览文件", "Space to Preview"), Toggle(Config.SpacePreview, v =>
         {
             Config.SpacePreview = v;


### PR DESCRIPTION
## 来自贡献者

很荣幸发现 MacDesk 这个项目，它完美解决了我长期以来对 Windows 桌面的几个痛点。作为一个 macOS 和 Windows 双系统用户，macOS 式的图标体验是我一直希望在 Windows 上拥有的。这次提交是我的微薄回馈——两个小改进都是我在日常使用中实际感受到的不顺手之处。代码改动尽量克制，不碰核心架构。如有任何不妥之处，恳请谅解，我愿意配合修改。

## 概述

两个桌面体验改进：

**拖拽原图标隐藏**：拖拽启动时原图标从半透明留影（Opacity 0.35）改为完全隐藏（Visibility Collapsed），避免原位残留虚影与跟手拖拽图像并存造成视觉割裂。松手后图标在落点恢复可见，网格模式下先瞬移到视觉落点再滑行到吸附格（不再从拖拽前旧位置起飞）。拖拽取消时回弹动画落地后恢复可见。

**回收站显示开关**：新增显示回收站设置项，首次启动默认值跟随原生桌面（读取注册表 HideDesktopIcons\NewStartPanel），后续以用户设置为准。关闭后回收站从桌面移除。

## 改动

- MainWindow.xaml.cs — 拖拽启动/落点/取消/回弹 4 处从 Opacity 切换为 Visibility；自愈逻辑扩展覆盖 Visibility 残留；网格模式落位先瞬移到视觉落点再滑行到吸附格
- Services/Settings.cs — 新增 ShowRecycleBin 属性，默认值读取原生桌面注册表
- Services/DesktopItemProvider.cs — Enumerate() 按 ShowRecycleBin 决定是否枚举回收站
- SettingsWindow.cs — 通用页新增显示回收站拨动开关

## 测试

- 拖拽桌面图标：原图标消失，跟手拖拽图像流畅，松手后图标在落点出现
- 网格模式拖拽：松手后图标先瞬移到视觉落点再滑行到吸附格，不从旧位置起飞
- 拖拽取消（Esc/右键）：回弹动画落地后图标恢复可见
- 回收站开关：关闭后回收站消失，开启后重新出现
- dotnet build 0 警告 0 错误

## 紧急度

低