### PR TITLE
【等待审核】feat(menu): 文件右键转发 Explorer 原生菜单

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1858,6 +1858,18 @@ public partial class MainWindow : Window
         else
             paths = new[] { iv.Entry.Path };
 
+        // 原生文件菜单模式（开关开 + 未按 Alt）：走 ShellContextMenu.Show 直出 Explorer 完整原生菜单
+        // （含所有第三方扩展的 IContextMenu），与 NativeBackgroundMenu 同理。Alt+右键 = 走自制菜单。
+        // 先探针：有不安全的第三方 shell 扩展（非 mscoree 类）则回退到隔离路径，避免主进程崩溃。
+        if (Config.NativeFileMenu && !Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+        {
+            bool safe = paths.Any(p => p.StartsWith("::")) || MenuHost.ProbeSafe(paths[0]);
+            if (safe)
+            {
+                ShellContextMenu.Show(paths, _hwnd, (int)pt.X, (int)pt.Y, _hwnd);
+                return;
+            }
+        }
         MenuHost.RequestFileMenu((int)pt.X, (int)pt.Y, paths, _hwnd);
     }
 

--- a/Services/MenuHost.cs
+++ b/Services/MenuHost.cs
@@ -453,7 +453,7 @@ internal static class MenuHost
     }
 
     /// <summary>该路径的原生文件菜单是否能安全加载（牺牲进程实测，非 0 退出码/崩溃 = 不安全）。</summary>
-    private static bool ProbeSafe(string path)
+    internal static bool ProbeSafe(string path)
     {
         string key = KindKey(path);
         lock (_probeGate)

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -58,6 +58,11 @@ internal sealed class Settings
     /// 弹它自己的现代/经典菜单）；此时按住 Alt 再右键才出 MacDesk 自制菜单。默认关。</summary>
     public bool NativeBackgroundMenu { get; set; }
 
+    /// <summary>文件/图标右键出 Explorer 原生 shell 菜单（完整 IContextMenu，含所有第三方扩展）。
+    /// 与 NativeBackgroundMenu 同理：默认关，开时 Alt+右键回退 MacDesk 自制菜单。
+    /// 注意：第三方 shell 扩展崩溃会带走 host 进程（菜单隔离在此路径不生效）。</summary>
+    public bool NativeFileMenu { get; set; }
+
     /// <summary>图标尺寸（base 图标 DIU，缩放因子 S = IconSize/64）。档位见 MainWindow.IconSizeSteps，
     /// 默认 64。Ctrl +/- 与外观页滑杆调整；不写 Canon（切档=切分辨率同理，仅显示现算）。</summary>
     public int IconSize { get; set; } = 64;
@@ -100,6 +105,7 @@ internal sealed class Settings
                     s.Language = lg.GetString()!;
                 if (doc.RootElement.TryGetProperty("SpacePreview", out var sp)) s.SpacePreview = sp.GetBoolean();
                 if (doc.RootElement.TryGetProperty("NativeBackgroundMenu", out var nb)) s.NativeBackgroundMenu = nb.GetBoolean();
+                if (doc.RootElement.TryGetProperty("NativeFileMenu", out var nf)) s.NativeFileMenu = nf.GetBoolean();
                 if (doc.RootElement.TryGetProperty("IconSize", out var iz) && iz.ValueKind == JsonValueKind.Number) s.IconSize = iz.GetInt32();
                 if (doc.RootElement.TryGetProperty("SoftwareRender", out var sr)) s.SoftwareRender = sr.GetBoolean();
             }
@@ -113,7 +119,7 @@ internal sealed class Settings
         try
         {
             File.WriteAllText(_file, JsonSerializer.Serialize(
-                new { FreePlacement, MenuBlacklist, MenuInMainProcess, AccentColor, UseStacks, StackGroupBy, DynamicWallpaper, DynamicNoShadows, DynamicNoAnimations, FastAutostart, Language, SpacePreview, NativeBackgroundMenu, IconSize, SoftwareRender },
+                new { FreePlacement, MenuBlacklist, MenuInMainProcess, AccentColor, UseStacks, StackGroupBy, DynamicWallpaper, DynamicNoShadows, DynamicNoAnimations, FastAutostart, Language, SpacePreview, NativeBackgroundMenu, NativeFileMenu, IconSize, SoftwareRender },
                 new JsonSerializerOptions { WriteIndented = true }));
         }
         catch { }

--- a/SettingsWindow.cs
+++ b/SettingsWindow.cs
@@ -707,18 +707,22 @@ internal sealed class SettingsWindow : Window
             Toggle(Config.NativeBackgroundMenu, v => { Config.NativeBackgroundMenu = v; Config.Save(); }),
             L.T("桌面空白处右键改为弹 Windows 原生桌面菜单", "Right-click empty desktop shows the native Windows desktop menu")));
         nativeSec.Children.Add(Separator());
+        nativeSec.Children.Add(Row(L.T("文件/图标使用 Windows 原生菜单", "Native Windows Menu on Files"),
+            Toggle(Config.NativeFileMenu, v => { Config.NativeFileMenu = v; Config.Save(); }),
+            L.T("文件或图标上右键出 Explorer 完整原生菜单（含所有第三方扩展）。\n注意：第三方 shell 扩展的崩溃会影响 MacDesk——推荐仅在自制菜单缺失你需要的内置项时开启。", "Right-click a file/icon to invoke Explorer's full native menu (with all third-party extensions).\nNote: third-party shell extension crashes may take down MacDesk — use only when the built-in menu lacks items you need.")));
+        nativeSec.Children.Add(Separator());
         nativeSec.Children.Add(new TextBlock
         {
             Text = L.T(
                 "操作逻辑（开启后）：\n" +
                 "• 空白处右键 = Windows 原生菜单（Explorer 弹它自己的现代或经典菜单，取决于你的系统设置——我们不重建，你系统里是哪款就出哪款）。\n" +
                 "• 按住 Alt 再右键 = MacDesk 自制菜单（整理、排序方式、使用叠放、更换壁纸、设置）。\n" +
-                "• 图标上的右键不受影响，始终是原生 shell 菜单。\n" +
+                "• 图标上的右键也不受影响，始终是原生 shell 菜单（如开启了文件原生菜单则是完整 Explorer 菜单，否则是 MacDesk 自制渲染的 shell 菜单）。\n" +
                 "注意：原生菜单里的\"查看\"\"排序方式\"\"显示桌面图标\"等作用于被隐藏的原生图标层，对 MacDesk 的图标不起作用——要排列 MacDesk 图标，用 Alt 菜单里的整理 / 排序方式 / 使用叠放。",
                 "How it works (when on):\n" +
                 "• Right-click empty desktop = the native Windows menu (Explorer shows its own modern or classic menu per your system — we don't rebuild it, you get whichever your system uses).\n" +
                 "• Hold Alt and right-click = the MacDesk menu (Clean Up, Sort By, Use Stacks, Change Wallpaper, Settings).\n" +
-                "• Right-clicking an icon is unaffected and always shows the native shell menu.\n" +
+                "• Right-clicking an icon is also unaffected and always shows the native shell menu (the full Explorer menu when Native File Menu is on, or MacDesk's own shell-menu rendering otherwise).\n" +
                 "Note: the native menu's View / Sort by / Show desktop icons act on the hidden native icon layer and do nothing to MacDesk icons — to arrange MacDesk icons use Clean Up / Sort By / Use Stacks in the Alt menu."),
             FontSize = 11,
             Foreground = Subtle,


### PR DESCRIPTION
## 概述

新增 NativeFileMenu 设置项：开启后文件/图标右键直出 Explorer 完整原生 shell 菜单（含所有第三方扩展的 IContextMenu，视觉、子菜单、扩展与 Explorer 右键完全一致）。与已有的 NativeBackgroundMenu 模式对等。

默认关，开启时 Alt+右键强制回退 MacDesk 自制菜单。内部集成了探针安全检查——有不安全第三方扩展的文件类型自动降级到隔离路径，避免主进程崩溃。

## 改动

- MainWindow.xaml.cs — ShowIconMenu 中新增 NativeFileMenu 分支，探针安全后调 ShellContextMenu.Show
- Services/Settings.cs — 新增 NativeFileMenu 属性（默认 false），读写序列化
- Services/MenuHost.cs — ProbeSafe 从 private 改为 internal，供 MainWindow 调用
- SettingsWindow.cs — 菜单页新增文件原生菜单拨动开关 + 更新帮助文本

## 测试

- 开关关闭（默认）：文件右键走现有 MenuHost 路径，行为不变
- 开关开启：文件右键弹出 Explorer 完整原生菜单（视觉、子菜单、扩展与 Explorer 一致）
- Alt+右键：强制走 MacDesk 自制菜单
- 探针降级：已知不安全的文件类型自动回退隔离路径
- dotnet build 0 警告 0 错误

## 紧急度

低